### PR TITLE
Quick fixes to reduce memory issues

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -43,3 +43,10 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
           stack: 'container'
+
+      - name: Check dyno state
+        run: |
+          heroku ps -a ${{ secrets.HEROKU_APP_NAME }}
+          heroku logs -n 50 -a ${{ secrets.HEROKU_APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,3 +45,10 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
           stack: 'container'
+
+      - name: Check dyno state
+        run: |
+          heroku ps -a ${{ secrets.HEROKU_APP_NAME }}
+          heroku logs -n 50 -a ${{ secrets.HEROKU_APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -69,6 +69,13 @@ ENV PORT=3000
 # Expose the port on which the API will listen
 EXPOSE 3000
 
+# Set environment variable to disable stdout buffering for Bun
+ENV BUN_STDOUT_BUFFERING=0
+
+# Add a health check to ensure the container is healthy
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s \
+  CMD curl -f http://localhost:${PORT:-3000}/health || exit 1
+
 # Run the server when the container launches
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["./server"]

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,24 +6,19 @@ import { config, documentation } from './config'
 import { standardResponses } from './libs/standard-responses'
 import { handleErrors } from './libs/handle-errors'
 
-import { app as handlerBops } from '@dpr/handler-bops'
+import {
+  app as handlerBops,
+  fetchAllApplications as fetchAllBopsApplications,
+  fetchApplication as fetchBopsApplication,
+  fetchAllApplicationDocuments as fetchAllBopsApplicationDocuments,
+  fetchAllApplicationPublicComments as fetchAllBopsApplicationPublicComments,
+  fetchAllApplicationSpecialistComments as fetchAllBopsApplicationSpecialistComments,
+  fetchApplicationSpecialistComment as fetchBopsApplicationSpecialistComment
+} from '@dpr/handler-bops'
 import { showRoutes } from './libs/show-routes'
 import { SchemaModel } from './schema'
 import { api } from './modules/api'
 import { requireClientHeaders } from './libs/client-headers'
-import { proxyBopsGet } from './libs/handle-requests'
-
-import { ENV_HANDLER_API as ENV } from '@dpr/config'
-import type {
-  PostSubmissionPublishedApplicationResponse,
-  PostSubmissionPublishedApplicationsResponse,
-  PostSubmissionPublishedDocumentsResponse,
-  PostSubmissionPublishedPublicCommentsResponse,
-  PostSubmissionPublishedSpecialistsResponse,
-  PostSubmissionPublishedSpecialistResponse
-} from '@dpr/odp-schemas/types/schemas/postSubmissionApplication/implementation/Endpoints.ts'
-
-const { API_BASE_URL } = ENV
 
 /**
  * @file Types for authentication middleware
@@ -83,7 +78,7 @@ const app = (userOptions?: ApiOptions) => {
       // )
       .use(
         openapi({
-          enabled: true,
+          enabled: !isProduction,
           path: '/docs',
           provider: 'swagger-ui',
           exclude: {
@@ -490,19 +485,10 @@ const app = (userOptions?: ApiOptions) => {
           app
             .get(
               `/applications`,
-              async ({ handler, client, service, query }) => {
+              async ({ handler, client, query }) => {
                 switch (handler) {
                   case 'bops': {
-                    const result =
-                      await proxyBopsGet<PostSubmissionPublishedApplicationsResponse>(
-                        {
-                          baseUrl: API_BASE_URL,
-                          path: `/api/handlers/bops/public/applications`,
-                          query,
-                          client,
-                          service
-                        }
-                      )
+                    const result = await fetchAllBopsApplications(client, query)
                     const { data, status } = result
                     const pagination =
                       'pagination' in result ? result.pagination : undefined
@@ -537,19 +523,13 @@ const app = (userOptions?: ApiOptions) => {
             )
             .get(
               `/applications/:applicationId`,
-              async ({ handler, client, service, query, params }) => {
+              async ({ handler, client, params }) => {
                 switch (handler) {
                   case 'bops': {
-                    const result =
-                      await proxyBopsGet<PostSubmissionPublishedApplicationResponse>(
-                        {
-                          baseUrl: API_BASE_URL,
-                          path: `/api/handlers/bops/public/applications/${params.applicationId}`,
-                          query,
-                          client,
-                          service
-                        }
-                      )
+                    const result = await fetchBopsApplication(
+                      client,
+                      params.applicationId
+                    )
                     const { data, status } = result
                     const pagination =
                       'pagination' in result ? result.pagination : undefined
@@ -584,19 +564,14 @@ const app = (userOptions?: ApiOptions) => {
             )
             .get(
               `/applications/:applicationId/documents`,
-              async ({ handler, client, service, query, params }) => {
+              async ({ handler, client, query, params }) => {
                 switch (handler) {
                   case 'bops': {
-                    const result =
-                      await proxyBopsGet<PostSubmissionPublishedDocumentsResponse>(
-                        {
-                          baseUrl: API_BASE_URL,
-                          path: `/api/handlers/bops/public/applications/${params.applicationId}/documents`,
-                          query,
-                          client,
-                          service
-                        }
-                      )
+                    const result = await fetchAllBopsApplicationDocuments(
+                      client,
+                      params.applicationId,
+                      query
+                    )
                     const { data, status } = result
                     const pagination =
                       'pagination' in result ? result.pagination : undefined
@@ -669,19 +644,14 @@ const app = (userOptions?: ApiOptions) => {
             )
             .get(
               `/applications/:applicationId/publicComments`,
-              async ({ handler, client, service, query, params }) => {
+              async ({ handler, client, query, params }) => {
                 switch (handler) {
                   case 'bops': {
-                    const result =
-                      await proxyBopsGet<PostSubmissionPublishedPublicCommentsResponse>(
-                        {
-                          baseUrl: API_BASE_URL,
-                          path: `/api/handlers/bops/public/applications/${params.applicationId}/publicComments`,
-                          query,
-                          client,
-                          service
-                        }
-                      )
+                    const result = await fetchAllBopsApplicationPublicComments(
+                      client,
+                      params.applicationId,
+                      query
+                    )
                     const { data, status } = result
                     const pagination =
                       'pagination' in result ? result.pagination : undefined
@@ -754,18 +724,14 @@ const app = (userOptions?: ApiOptions) => {
             )
             .get(
               `/applications/:applicationId/specialistComments`,
-              async ({ handler, client, service, query, params }) => {
+              async ({ handler, client, query, params }) => {
                 switch (handler) {
                   case 'bops': {
                     const result =
-                      await proxyBopsGet<PostSubmissionPublishedSpecialistsResponse>(
-                        {
-                          baseUrl: API_BASE_URL,
-                          path: `/api/handlers/bops/public/applications/${params.applicationId}/specialistComments`,
-                          query,
-                          client,
-                          service
-                        }
+                      await fetchAllBopsApplicationSpecialistComments(
+                        client,
+                        params.applicationId,
+                        query
                       )
                     const { data, status } = result
                     const pagination =
@@ -804,19 +770,15 @@ const app = (userOptions?: ApiOptions) => {
             )
             .get(
               `/applications/:applicationId/specialistComments/:specialistId`,
-              async ({ handler, client, service, query, params }) => {
+              async ({ handler, client, query, params }) => {
                 switch (handler) {
                   case 'bops': {
-                    const result =
-                      await proxyBopsGet<PostSubmissionPublishedSpecialistResponse>(
-                        {
-                          baseUrl: API_BASE_URL,
-                          path: `/api/handlers/bops/public/applications/${params.applicationId}/specialistComments/${params.specialistId}`,
-                          query,
-                          client,
-                          service
-                        }
-                      )
+                    const result = await fetchBopsApplicationSpecialistComment(
+                      client,
+                      params.applicationId,
+                      params.specialistId,
+                      query
+                    )
                     const { data, status } = result
                     const pagination =
                       'pagination' in result ? result.pagination : undefined

--- a/handlers/bops/src/index.ts
+++ b/handlers/bops/src/index.ts
@@ -228,3 +228,14 @@ const app = (userOptions?: HandlerBopsOptions) => {
 
 export { app }
 export type App = typeof app
+
+export {
+  fetchAllApplications,
+  fetchApplication
+} from './modules/applications'
+export { fetchAllApplicationDocuments } from './modules/documents'
+export { fetchAllApplicationPublicComments } from './modules/publicComments'
+export {
+  fetchAllApplicationSpecialistComments,
+  fetchApplicationSpecialistComment
+} from './modules/specialistComments'

--- a/handlers/bops/src/libs/requests/requests.ts
+++ b/handlers/bops/src/libs/requests/requests.ts
@@ -79,17 +79,24 @@ export async function handleBopsGetRequest<T>(
 ): Promise<T> {
   const { apiUrl } = getClientConfig(client)
   console.log(`[handleBopsGetRequest] ${apiUrl}${url}`)
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 25000)
   try {
     const response = await fetch(`${apiUrl}${url}`, {
-      method: 'GET'
+      method: 'GET',
+      signal: controller.signal
     })
+    clearTimeout(timeoutId)
     return await handleResponse<T>(response, conversionCallback)
   } catch (error) {
+    clearTimeout(timeoutId)
+    const isTimeout =
+      error instanceof Error && error.name === 'AbortError'
     return {
       data: null,
       status: {
-        code: 500,
-        message: 'Internal server error',
+        code: isTimeout ? 504 : 500,
+        message: isTimeout ? 'Gateway Timeout' : 'Internal server error',
         detail: (error as Error).message
       }
     } as T

--- a/packages/config/env/index.ts
+++ b/packages/config/env/index.ts
@@ -52,18 +52,15 @@ export const ENV_HANDLER_BOPS = {
       ? 'i-am-the-admin-coo-coo-ca-choo'
       : process.env.INTERNAL_API_TOKEN ?? '',
   // if applications endpoint is still in 'legacy' mode (ie not ODP yet)
-  BOPS_LEGACY_APPLICATIONS:
-    process.env.BOPS_LEGACY_APPLICATIONS === 'true' ? 'true' : 'false',
-  BOPS_LEGACY_APPLICATION:
-    process.env.BOPS_LEGACY_APPLICATION === 'true' ? 'true' : 'false',
-  BOPS_LEGACY_DOCUMENTS:
-    process.env.BOPS_LEGACY_DOCUMENTS === 'true' ? 'true' : 'false',
+  BOPS_LEGACY_APPLICATIONS: process.env.BOPS_LEGACY_APPLICATIONS === 'true',
+  BOPS_LEGACY_APPLICATION: process.env.BOPS_LEGACY_APPLICATION === 'true',
+  BOPS_LEGACY_DOCUMENTS: process.env.BOPS_LEGACY_DOCUMENTS === 'true',
   BOPS_LEGACY_PUBLIC_COMMENTS:
-    process.env.BOPS_LEGACY_PUBLIC_COMMENTS === 'true' ? 'true' : 'false',
+    process.env.BOPS_LEGACY_PUBLIC_COMMENTS === 'true',
   BOPS_LEGACY_SPECIALIST_COMMENTS:
-    process.env.BOPS_LEGACY_SPECIALIST_COMMENTS === 'true' ? 'true' : 'false',
+    process.env.BOPS_LEGACY_SPECIALIST_COMMENTS === 'true',
   BOPS_LEGACY_SPECIALIST_COMMENT:
-    process.env.BOPS_LEGACY_SPECIALIST_COMMENT === 'true' ? 'true' : 'false'
+    process.env.BOPS_LEGACY_SPECIALIST_COMMENT === 'true'
 }
 
 // applications - api
@@ -80,18 +77,15 @@ export const ENV_HANDLER_API = {
   API_BASE_URL:
     process.env.API_BASE_URL || `http://localhost:${PORT(ports['apps-api'])}`,
   // if applications endpoint is still in 'legacy' mode (ie not ODP yet)
-  BOPS_LEGACY_APPLICATIONS:
-    process.env.BOPS_LEGACY_APPLICATIONS === 'true' ? 'true' : 'false',
-  BOPS_LEGACY_APPLICATION:
-    process.env.BOPS_LEGACY_APPLICATION === 'true' ? 'true' : 'false',
-  BOPS_LEGACY_DOCUMENTS:
-    process.env.BOPS_LEGACY_DOCUMENTS === 'true' ? 'true' : 'false',
+  BOPS_LEGACY_APPLICATIONS: process.env.BOPS_LEGACY_APPLICATIONS === 'true',
+  BOPS_LEGACY_APPLICATION: process.env.BOPS_LEGACY_APPLICATION === 'true',
+  BOPS_LEGACY_DOCUMENTS: process.env.BOPS_LEGACY_DOCUMENTS === 'true',
   BOPS_LEGACY_PUBLIC_COMMENTS:
-    process.env.BOPS_LEGACY_PUBLIC_COMMENTS === 'true' ? 'true' : 'false',
+    process.env.BOPS_LEGACY_PUBLIC_COMMENTS === 'true',
   BOPS_LEGACY_SPECIALIST_COMMENTS:
-    process.env.BOPS_LEGACY_SPECIALIST_COMMENTS === 'true' ? 'true' : 'false',
+    process.env.BOPS_LEGACY_SPECIALIST_COMMENTS === 'true',
   BOPS_LEGACY_SPECIALIST_COMMENT:
-    process.env.BOPS_LEGACY_SPECIALIST_COMMENT === 'true' ? 'true' : 'false'
+    process.env.BOPS_LEGACY_SPECIALIST_COMMENT === 'true'
 }
 
 // export const API_URL = process.env.API_URL ?? 'http://localhost:3000'


### PR DESCRIPTION
* Added a timeout to any BOPs request - if BOPS is slow for any reason the request would hang for the full 30 seconds, using up memory until heroku killed the request (H12 error). This was doubled by the multiple requests bug below
* The `BOPS_LEGACY` flags are set to `"true"` and not `true` this meant that `convertBopsApplicationToOdp` always ran even when explicitly disabled. Not an issue right now since we're converting every request
* By doing a request to our own API using request through our API we were dealing with the same (large) set of json twice - exporting and importing the fetch methods is a more efficient way to do this
* Disabled swagger in production swagger we have a high idle base-line for our code so anything that can reduce it for now is helpful 
* added logs to the deploy actions to catch anything immediately on server start
* Updated the container to show logs in heroku 🤞
* Added `HEALTHCHECK` to docker container