### PR TITLE
More small memory fixes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -77,28 +77,26 @@ const app = (userOptions?: ApiOptions) => {
       //   })
       // )
       .use(
-        openapi({
-          enabled: !isProduction,
-          path: '/docs',
-          provider: 'swagger-ui',
-          exclude: {
-            paths: ['/']
-            //  /^\/api\/handlers\/bops/ Exclude all BOPS handler routes from OpenAPI documentation
-          },
-          documentation,
-          references: fromTypes(
-            isProduction ? path.resolve('dist/types/app.d.ts') : 'src/app.ts',
-            {
-              projectRoot: isProduction
-                ? path.join(import.meta.dir)
-                : path.join(import.meta.dir, '..'),
-              tsconfigPath: isProduction
-                ? path.join(import.meta.dir, 'tsconfig.build.json')
-                : path.join(import.meta.dir, '..', 'tsconfig.build.json'),
-              debug: options.debug
-            }
-          )
-        })
+        isProduction
+          ? new Elysia({ name: 'openapi-disabled' })
+          : openapi({
+              path: '/docs',
+              provider: 'swagger-ui',
+              exclude: {
+                paths: ['/']
+                //  /^\/api\/handlers\/bops/ Exclude all BOPS handler routes from OpenAPI documentation
+              },
+              documentation,
+              references: fromTypes('src/app.ts', {
+                projectRoot: path.join(import.meta.dir, '..'),
+                tsconfigPath: path.join(
+                  import.meta.dir,
+                  '..',
+                  'tsconfig.build.json'
+                ),
+                debug: options.debug
+              })
+            })
       )
       .use(standardResponses)
       .use(SchemaModel)

--- a/handlers/bops/src/modules/applications/applications.ts
+++ b/handlers/bops/src/modules/applications/applications.ts
@@ -53,8 +53,10 @@ export const fetchApplication = async (
 ): Promise<PostSubmissionPublishedApplicationResponse> => {
   try {
     const url = getPublicApplicationUrl(applicationId)
-    const results =
-      await handleBopsGetRequest<PostSubmissionPublishedApplicationResponse>(
+    const submissionUrl = getPublicApplicationSubmissionUrl(applicationId)
+
+    const [results, submission] = await Promise.all([
+      handleBopsGetRequest<PostSubmissionPublishedApplicationResponse>(
         client,
         url,
         async (response: Response) => {
@@ -66,25 +68,19 @@ export const fetchApplication = async (
           }
           return input
         }
-      )
+      ),
+      handleBopsGetRequest<unknown>(client, submissionUrl).catch((e) => {
+        console.warn('Couldnt fetch submission', e)
+        return null
+      })
+    ])
 
-    try {
-      const submissionUrl = getPublicApplicationSubmissionUrl(applicationId)
-      const submission = await handleBopsGetRequest<unknown>(
-        client,
-        submissionUrl
-      )
-
-      if (submission && (submission as { submission?: unknown }).submission) {
-        if (results && results?.data) {
-          results.data.submission = (
-            submission as { submission: unknown }
-          ).submission
-        }
+    if (submission && (submission as { submission?: unknown }).submission) {
+      if (results && results?.data) {
+        results.data.submission = (
+          submission as { submission: unknown }
+        ).submission
       }
-    } catch (e) {
-      console.warn('Couldnt fetch submission', e)
-      // throw new Error('Error fetching applications')
     }
 
     return results


### PR DESCRIPTION
* Skip `openapi()` and `fromTypes()` calls in prod - previous fix wasn't enough the `fromTypes()` was still run and its a bit of a beast
* Fetching application and submission requests to BOPS are run in parallel not sequentially. This reduces latency for the /detail endpoint by ~half and reduces the window during which both responses are in memory simultaneously 🤞